### PR TITLE
Add httpOnly refresh token auth and OAuth/password conflict handling

### DIFF
--- a/controllers/oauthController.js
+++ b/controllers/oauthController.js
@@ -1,6 +1,10 @@
 const { OAuth2Client } = require("google-auth-library");
-const jwt = require("jsonwebtoken");
 const User = require("../models/User");
+const {
+  generateAccessToken,
+  generateRefreshToken,
+  setRefreshTokenCookie,
+} = require("../utils/tokenUtils");
 
 // Initialize a client with the client ID from environment
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
@@ -28,23 +32,28 @@ exports.googleLogin = async (req, res) => {
         // find or create the user
         let user = await User.findOne({ email });
         if (!user) {
-            user = new User({ name: name || email, email, googleId });
+            user = new User({ name: name || email, email, googleId, authProvider: "google" });
             await user.save();
         } else if (!user.googleId) {
             // if existing user did not have googleId, store it
             user.googleId = googleId;
+            if (user.authProvider === "local" && !user.password) {
+                user.authProvider = "google";
+            }
             await user.save();
         }
 
-        const jwtToken = jwt.sign(
-            { id: user._id, role: user.role,  email: user.email },
-            process.env.JWT_SECRET,
-            { expiresIn: "1h" }
-        );
+        const accessToken = generateAccessToken(user);
+        const refreshToken = generateRefreshToken();
+
+        user.refreshToken = refreshToken;
+        await user.save();
+
+        setRefreshTokenCookie(res, refreshToken);
 
         res.json({
-            token: jwtToken,
-            user: { id: user._id, name: user.name, email: user.email, picture },
+            accessToken,
+            user: { id: user._id, name: user.name, email: user.email, role: user.role, picture },
         });
     } catch (err) {
         console.error("Google login error", err);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -3,22 +3,28 @@ const Ticket = require("../models/Ticket");
 const Team = require("../models/Team");
 const CourseEnrollment = require("../models/CourseEnrollment");
 const bcrypt = require("bcryptjs");
-const jwt = require("jsonwebtoken");
+const {
+  generateAccessToken,
+  generateRefreshToken,
+  setRefreshTokenCookie,
+  clearRefreshTokenCookie,
+} = require("../utils/tokenUtils");
 
 exports.register = async (req, res) => {
   try {
     const { name, email, password } = req.body;
     const existingUser = await User.findOne({ email });
     if (existingUser) {
-      if (!existingUser.password) {
+      if (existingUser.authProvider === "google" || (!existingUser.password && existingUser.googleId)) {
         return res.status(400).json({
           message: "This email is linked to a Google account. Please log in with Google.",
+          authMethod: "google",
         });
       }
       return res.status(400).json({ message: "Email already in use." });
     }
     const hashedPassword = await bcrypt.hash(password, 10);
-    const user = new User({ name, email, password: hashedPassword, role: "user" });
+    const user = new User({ name, email, password: hashedPassword, authProvider: "local", role: "user" });
     await user.save();
     res.status(201).json({ message: "User registered successfully" });
   } catch (err) {
@@ -32,25 +38,64 @@ exports.login = async (req, res) => {
     const user = await User.findOne({ email });
     if (!user) return res.status(400).json({ message: "Invalid credentials" });
 
-    if (!user.password) {
+    if (user.authProvider === "google" || (!user.password && user.googleId)) {
       return res.status(400).json({
         message: "This account uses Google Sign-In. Please log in with Google.",
+        authMethod: "google",
       });
     }
 
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) return res.status(400).json({ message: "Invalid credentials" });
 
-    const token = jwt.sign(
-      { id: user._id, role: user.role, name: user.name, email: user.email },
-      process.env.JWT_SECRET || "secret",
-      { expiresIn: "7d" }
-    );
+    const accessToken = generateAccessToken(user);
+    const refreshToken = generateRefreshToken();
+
+    user.refreshToken = refreshToken;
+    await user.save();
+
+    setRefreshTokenCookie(res, refreshToken);
 
     res.json({
-      token,
+      accessToken,
       user: { id: user._id, name: user.name, email: user.email, role: user.role },
     });
+  } catch (err) {
+    res.status(500).json({ message: "Server error" });
+  }
+};
+
+exports.refresh = async (req, res) => {
+  try {
+    const { refreshToken } = req.cookies;
+    if (!refreshToken) {
+      return res.status(401).json({ message: "No refresh token" });
+    }
+
+    const user = await User.findOne({ refreshToken });
+    if (!user) {
+      clearRefreshTokenCookie(res);
+      return res.status(403).json({ message: "Invalid refresh token" });
+    }
+
+    const accessToken = generateAccessToken(user);
+    res.json({
+      accessToken,
+      user: { id: user._id, name: user.name, email: user.email, role: user.role },
+    });
+  } catch (err) {
+    res.status(500).json({ message: "Server error" });
+  }
+};
+
+exports.logout = async (req, res) => {
+  try {
+    const { refreshToken } = req.cookies;
+    if (refreshToken) {
+      await User.findOneAndUpdate({ refreshToken }, { refreshToken: null });
+    }
+    clearRefreshTokenCookie(res);
+    res.json({ message: "Logged out successfully" });
   } catch (err) {
     res.status(500).json({ message: "Server error" });
   }
@@ -59,7 +104,7 @@ exports.login = async (req, res) => {
 exports.getProfile = async (req, res) => {
 
   try {
-    const user = await User.findById(req.user.id).select("-password");
+    const user = await User.findById(req.user.id).select("-password -refreshToken");
     if (!user) return res.status(404).json({ message: "User not found" });
 
     const tickets = await Ticket.find({ buyerEmail: user.email, status: "paid" })

--- a/index.js
+++ b/index.js
@@ -6,12 +6,14 @@ const connectDB = require("./config/db"); // Import the database connection func
 connectDB();
 
 const cors = require("cors");
+const cookieParser = require("cookie-parser");
 
 const app = express();
 
 app.use("/courses/webhook", express.raw({ type: "application/json" }));
 
 app.use(express.json());
+app.use(cookieParser());
 
 // Update this:
 app.use(

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,17 +1,6 @@
 const jwt = require("jsonwebtoken");
 
-function generateToken(user) {
-  return jwt.sign(
-    { id: user._id, role: user.role },
-    process.env.JWT_SECRET,
-    {
-      expiresIn: "1h",
-    }
-  );
-}
-
 function authenticateToken(req, res, next) {
-  // console.log("AUTH MIDDLEWARE: headers:", req.headers);
   const authHeader = req.headers["authorization"];
   const token = authHeader && authHeader.split(" ")[1];
 
@@ -21,8 +10,6 @@ function authenticateToken(req, res, next) {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    // console.log("AUTH MIDDLEWARE: decoded:", decoded);
-    // always attach user payload to req.user
     req.user = decoded;
     next();
   } catch (err) {
@@ -31,6 +18,4 @@ function authenticateToken(req, res, next) {
   }
 }
 
-
-
-module.exports =  authenticateToken;
+module.exports = authenticateToken;

--- a/models/User.js
+++ b/models/User.js
@@ -5,13 +5,19 @@ const userSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, unique: true, required: true },
   password: { type: String, required: false, default: null},
-  role: { 
-    type: String, 
+  authProvider: {
+    type: String,
+    enum: ["local", "google"],
+    default: "local"
+  },
+  role: {
+    type: String,
     enum: ["user", "moderator", "admin"],
     default: "user"
   },
   isActive: { type: Boolean, default: true },
   isBanned: { type: Boolean, default: false },
+  refreshToken: { type: String, default: null },
 
 }, { timestamps: true });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bcryptjs": "^3.0.2",
         "body-parser": "^2.2.0",
         "cloudinary": "^2.9.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
@@ -1704,11 +1705,23 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/cookie-signature": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bcryptjs": "^3.0.2",
     "body-parser": "^2.2.0",
     "cloudinary": "^2.9.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",

--- a/routes/users.js
+++ b/routes/users.js
@@ -7,6 +7,8 @@ const authMiddleware = require("../middleware/authMiddleware");
 router.post("/google", authController.googleLogin);
 router.post("/login", userController.login);
 router.post("/register", userController.register);
+router.post("/refresh", userController.refresh);
+router.post("/logout", userController.logout);
 router.get("/profile", authMiddleware, userController.getProfile);
 
 module.exports = router;

--- a/utils/tokenUtils.js
+++ b/utils/tokenUtils.js
@@ -1,0 +1,45 @@
+const jwt = require("jsonwebtoken");
+const crypto = require("crypto");
+
+const ACCESS_TOKEN_EXPIRY = "15m";
+const REFRESH_TOKEN_EXPIRY = "7d";
+
+function generateAccessToken(user) {
+  return jwt.sign(
+    { id: user._id, role: user.role, name: user.name, email: user.email },
+    process.env.JWT_SECRET,
+    { expiresIn: ACCESS_TOKEN_EXPIRY }
+  );
+}
+
+function generateRefreshToken() {
+  return crypto.randomBytes(40).toString("hex");
+}
+
+function setRefreshTokenCookie(res, refreshToken) {
+  const isProduction = process.env.NODE_ENV === "production";
+  res.cookie("refreshToken", refreshToken, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: isProduction ? "none" : "lax",
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+    path: "/",
+  });
+}
+
+function clearRefreshTokenCookie(res) {
+  const isProduction = process.env.NODE_ENV === "production";
+  res.clearCookie("refreshToken", {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: isProduction ? "none" : "lax",
+    path: "/",
+  });
+}
+
+module.exports = {
+  generateAccessToken,
+  generateRefreshToken,
+  setRefreshTokenCookie,
+  clearRefreshTokenCookie,
+};


### PR DESCRIPTION
Replace single long-lived JWT with short-lived access token (15min) + httpOnly refresh token cookie (7d). Add /users/refresh and /users/logout endpoints. Add authProvider field to User model and return authMethod in login errors so frontend can guide Google-linked users to the correct sign-in flow.