### PR TITLE
Add Access-Control-Allow-Credentials header to fix refresh token cook…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
                 {
                     "key": "Access-Control-Allow-Headers",
                     "value": "Content-Type, Authorization"
+                },
+                {
+                    "key": "Access-Control-Allow-Credentials",
+                    "value": "true"
                 }
             ]
         }


### PR DESCRIPTION
…ie in production

Without this header, the browser blocks Set-Cookie from cross-origin responses, preventing the refresh token cookie from being stored — silently logging users out.