### PR TITLE
Fix express-rate-limit proxy header errors on Vercel

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ const cookieParser = require("cookie-parser");
 
 const app = express();
 
+// Trust the first proxy (Vercel) so express-rate-limit reads the real
+// client IP from X-Forwarded-For / Forwarded headers instead of erroring.
+app.set("trust proxy", 1);
+
 const allowedOrigins = [process.env.FRONT_END_URL?.replace(/\/$/, "")];
 if (process.env.NODE_ENV !== "production") {
   allowedOrigins.push("http://localhost:5173");


### PR DESCRIPTION
Set trust proxy to 1 so Express reads the real client IP from X-Forwarded-For/Forwarded headers behind Vercel's reverse proxy, resolving ERR_ERL_UNEXPECTED_X_FORWARDED_FOR and ERR_ERL_FORWARDED_HEADER.